### PR TITLE
Keyboard is now cleared on reset.

### DIFF
--- a/src/StateBehavior.cpp
+++ b/src/StateBehavior.cpp
@@ -16,6 +16,7 @@
 #include "SoundUtil.h"
 #include "BallGroup.h"
 #include "Loader.h"
+#include "Keyboard.h"
 
 StateItem::StateItem() {
   m_iActSig = -1;
@@ -280,6 +281,7 @@ void StateBehavior::StdOnSignal() {
 				      m_vtxRot.z + p_CurrentStateItem->m_vtxRot.z);
 			
     }
+    Keyboard::clear();
   } else {
     vector<StateItem*>::iterator iter = m_vStateItem.begin();
     vector<StateItem*>::iterator end = m_vStateItem.end();


### PR DESCRIPTION
This fixes an issue where, if the flippers were up when the game ended, after a reset they would remain up.