### PR TITLE
Keyboard is now cleared on reset.

### DIFF
--- a/data/gnu/ModuleGnu.cpp
+++ b/data/gnu/ModuleGnu.cpp
@@ -334,6 +334,7 @@ public:
         //which ball do we activate if we just locked a ball?
         int i = getFirstDeadBall();
         if (i > -1) {
+          if (i == 0) SendSignal(loader->getSignal("game_start"), 0, this->getParent(), NULL);
           SendSignal( PBL_SIG_BALL_ON, 0, this->getParent(), NULL );
           table->activateBall(i, 19.5f, 0.0f, 30.0f);   
           m_iCurrentBallSlot = i;

--- a/src/ArmBehavior.cpp
+++ b/src/ArmBehavior.cpp
@@ -19,7 +19,7 @@ ArmBehavior::ArmBehavior(bool right) : Behavior() {
   m_bTilt = false;
   m_bRight = right;
   m_iCount = 0;
-  m_bOn = false;
+  m_bActive = false;
   m_iSound = -1;
   m_bFirst = true;
   this->setType(PBL_TYPE_ARMBEH);
@@ -35,15 +35,21 @@ void ArmBehavior::StdOnSignal() {
     this->getParent()->setUserProperty(PBL_UNACTIVE_ARM);
     this->getParent()->unsetUserProperty(PBL_ACTIVE_ARM);
     this->getParent()->setRotation(0.0f, m_vtxRot.y, 0.0f);
-    m_bOn = false;
+    m_bActive = false;
   }
   ElseOnSignal(PBL_SIG_TILT) {
     m_bTilt = true;
   }
+  ElseOnSignal(PBL_SIG_GAME_START) {
+    m_bActive = true;
+  }
+  ElseOnSignal(PBL_SIG_GAME_OVER) {
+    m_bActive = false;
+  }
 }
 
 void ArmBehavior::doArm(EMKey key) {
-  if (Keyboard::isKeyDown(key) && !m_bTilt) {
+  if (Keyboard::isKeyDown(key) && !m_bTilt && m_bActive) {
     if (m_iCount < 10) {
       m_iCount++;
       this->getParent()->setUserProperty(PBL_ACTIVE_ARM);

--- a/src/ArmBehavior.h
+++ b/src/ArmBehavior.h
@@ -33,7 +33,7 @@ class ArmBehavior : public Behavior {
   Vertex3D m_vtxRot;
   bool m_bRight;
   int m_iCount;
-  bool m_bOn;
+  bool m_bActive;
   int m_iSound;
   bool m_bFirst;
   bool m_bTilt;

--- a/src/StateBehavior.cpp
+++ b/src/StateBehavior.cpp
@@ -16,6 +16,7 @@
 #include "SoundUtil.h"
 #include "BallGroup.h"
 #include "Loader.h"
+#include "Keyboard.h"
 
 StateItem::StateItem() {
   m_iActSig = -1;
@@ -280,6 +281,7 @@ void StateBehavior::StdOnSignal() {
 				      m_vtxRot.z + p_CurrentStateItem->m_vtxRot.z);
 			
     }
+    Keyboard::clear();
   } else {
     vector<StateItem*>::iterator iter = m_vStateItem.begin();
     vector<StateItem*>::iterator end = m_vStateItem.end();


### PR DESCRIPTION
This fixes an issue where, if the flippers were up when the game ended, after a reset they would remain up.