### PR TITLE
Update On-Screen Messages with Settings

### DIFF
--- a/data/gnu/ModuleGnu.cpp
+++ b/data/gnu/ModuleGnu.cpp
@@ -6,6 +6,13 @@
     copyright            : (C) 2001 by Henrik Enqvist
                            (C) 2013 Ben Asselstine
     email                : henqvist@excite.com
+
+
+    ========================= Modifications =========================
+
+        Apr. 6, 2017:
+            Send the "game_start" signal. (c30zD)
+
 ***************************************************************************/
 
 #include "Private.h"

--- a/data/locale/pinball.pot
+++ b/data/locale/pinball.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-31 23:42+0200\n"
+"POT-Creation-Date: 2017-12-13 19:33+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,394 +17,408 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../../src/Pinball.cpp:107 ../../src/Pinball.cpp:515
+#: ../../src/Pinball.cpp:114 ../../src/Pinball.cpp:525
 msgid "High Scores"
 msgstr ""
 
-#: ../../src/Pinball.cpp:108
+#: ../../src/Pinball.cpp:115
 msgid "table: "
 msgstr ""
 
-#: ../../src/Pinball.cpp:126
+#: ../../src/Pinball.cpp:133
 msgid "No Table Loaded!"
 msgstr ""
 
-#: ../../src/Pinball.cpp:129
+#: ../../src/Pinball.cpp:136
 msgid "Hit any key for main menu..."
 msgstr ""
 
-#: ../../src/Pinball.cpp:146
+#: ../../src/Pinball.cpp:153
 msgid "press a key"
 msgstr ""
 
-#: ../../src/Pinball.cpp:162 ../../base/Config.cpp:169
+#: ../../src/Pinball.cpp:169 ../../base/Config.cpp:169
 msgid "unknown"
 msgstr ""
 
-#: ../../src/Pinball.cpp:374
+#: ../../src/Pinball.cpp:383
 msgid "LOADING"
 msgstr ""
 
-#: ../../src/Pinball.cpp:386
+#: ../../src/Pinball.cpp:395
 msgid "OK"
 msgstr ""
 
-#: ../../src/Pinball.cpp:392
+#: ../../src/Pinball.cpp:401
 msgid "ERROR"
 msgstr ""
 
-#: ../../src/Pinball.cpp:504
+#: ../../src/Pinball.cpp:515
 msgid "main menu"
 msgstr ""
 
-#: ../../src/Pinball.cpp:507
+#: ../../src/Pinball.cpp:517
 msgid "play"
 msgstr ""
 
-#: ../../src/Pinball.cpp:511
+#: ../../src/Pinball.cpp:521
 msgid "load table"
 msgstr ""
 
-#: ../../src/Pinball.cpp:519
+#: ../../src/Pinball.cpp:529
 msgid "config"
 msgstr ""
 
-#: ../../src/Pinball.cpp:522
+#: ../../src/Pinball.cpp:532
 msgid "exit"
 msgstr ""
 
-#: ../../src/Pinball.cpp:526
+#: ../../src/Pinball.cpp:536
 msgid "graphics"
 msgstr ""
 
-#: ../../src/Pinball.cpp:529
+#: ../../src/Pinball.cpp:539
 msgid "audio"
 msgstr ""
 
-#: ../../src/Pinball.cpp:532
+#: ../../src/Pinball.cpp:542
 msgid "keyboard"
 msgstr ""
 
-#: ../../src/Pinball.cpp:533
+#: ../../src/Pinball.cpp:543
 msgid "shortcuts for view change F5-F8"
 msgstr ""
 
-#: ../../src/Pinball.cpp:613
+#: ../../src/Pinball.cpp:623
 msgid "view:         classic"
 msgstr ""
 
-#: ../../src/Pinball.cpp:614
+#: ../../src/Pinball.cpp:624
 msgid "view:   softly moving"
 msgstr ""
 
-#: ../../src/Pinball.cpp:615
+#: ../../src/Pinball.cpp:625
 msgid "view:          moving"
 msgstr ""
 
-#: ../../src/Pinball.cpp:616
+#: ../../src/Pinball.cpp:626
 msgid "view:             top"
 msgstr ""
 
-#: ../../src/Pinball.cpp:620
+#: ../../src/Pinball.cpp:632
 msgid "screen:    fullscreen"
 msgstr ""
 
-#: ../../src/Pinball.cpp:621
+#: ../../src/Pinball.cpp:633
 msgid "screen:      windowed"
 msgstr ""
 
-#: ../../src/Pinball.cpp:625
+#: ../../src/Pinball.cpp:637
 msgid "brightness:    =....."
 msgstr ""
 
-#: ../../src/Pinball.cpp:626
+#: ../../src/Pinball.cpp:638
 msgid "brightness:    ==...."
 msgstr ""
 
-#: ../../src/Pinball.cpp:627
+#: ../../src/Pinball.cpp:639
 msgid "brightness:    ===..."
 msgstr ""
 
-#: ../../src/Pinball.cpp:628
+#: ../../src/Pinball.cpp:640
 msgid "brightness:    ====.."
 msgstr ""
 
-#: ../../src/Pinball.cpp:629
+#: ../../src/Pinball.cpp:641
 msgid "brightness:    =====."
 msgstr ""
 
-#: ../../src/Pinball.cpp:630
+#: ../../src/Pinball.cpp:642
 msgid "brightness:    ======"
 msgstr ""
 
-#: ../../src/Pinball.cpp:635
-msgid "screen width:     340"
+#: ../../src/Pinball.cpp:647
+msgid "screen width:     320"
 msgstr ""
 
-#: ../../src/Pinball.cpp:636
+#: ../../src/Pinball.cpp:648
 msgid "screen width:     400"
 msgstr ""
 
-#: ../../src/Pinball.cpp:637
+#: ../../src/Pinball.cpp:649
 msgid "screen width:     512"
 msgstr ""
 
-#: ../../src/Pinball.cpp:638
+#: ../../src/Pinball.cpp:650
 msgid "screen width:     640"
 msgstr ""
 
-#: ../../src/Pinball.cpp:639
-msgid "screen width:     800"
-msgstr ""
-
-#: ../../src/Pinball.cpp:640
-msgid "screen width:     864"
-msgstr ""
-
-#: ../../src/Pinball.cpp:641
-msgid "screen width:    1024"
-msgstr ""
-
-#: ../../src/Pinball.cpp:642
-msgid "screen width:    1280"
-msgstr ""
-
-#: ../../src/Pinball.cpp:643
-msgid "screen width:    1680"
-msgstr ""
-
-#: ../../src/Pinball.cpp:644
-msgid "screen width:    1920"
-msgstr ""
-
-#: ../../src/Pinball.cpp:649
-msgid "ratio:      0.5 (1/2)"
-msgstr ""
-
-#: ../../src/Pinball.cpp:650
-msgid "ratio:        1 (1/1)"
-msgstr ""
-
 #: ../../src/Pinball.cpp:651
-msgid "ratio:      1.2 (5/4)"
+msgid "screen width:     720"
 msgstr ""
 
 #: ../../src/Pinball.cpp:652
-msgid "ratio:      1.3 (4/3)"
+msgid "screen width:     800"
 msgstr ""
 
 #: ../../src/Pinball.cpp:653
-msgid "ratio:      1.5 (3/2)"
+msgid "screen width:     864"
 msgstr ""
 
 #: ../../src/Pinball.cpp:654
-msgid "ratio:    1.6 (16/10)"
+msgid "screen width:     900"
 msgstr ""
 
 #: ../../src/Pinball.cpp:655
-msgid "ratio:     1.7 (16/9)"
+msgid "screen width:    1024"
 msgstr ""
 
 #: ../../src/Pinball.cpp:656
-msgid "ratio:      1.8 (9/5)"
+msgid "screen width:    1080"
 msgstr ""
 
 #: ../../src/Pinball.cpp:657
-msgid "ratio:        2 (2/1)"
+msgid "screen width:    1280"
 msgstr ""
 
-#: ../../src/Pinball.cpp:662
-msgid "texture:       nicest"
+#: ../../src/Pinball.cpp:658
+msgid "screen width:    1680"
 msgstr ""
 
-#: ../../src/Pinball.cpp:663
-msgid "texture:      fastest"
+#: ../../src/Pinball.cpp:659
+msgid "screen width:    1920"
 msgstr ""
 
 #: ../../src/Pinball.cpp:664
-msgid "texture:         none"
+msgid "ratio:      0.5 (1/2)"
 msgstr ""
 
-#: ../../src/Pinball.cpp:668
-msgid "show fps:          no"
+#: ../../src/Pinball.cpp:671
+msgid "ratio:        1 (1/1)"
 msgstr ""
 
-#: ../../src/Pinball.cpp:669
-msgid "show fps:         yes"
+#: ../../src/Pinball.cpp:672
+msgid "ratio:      1.2 (5/4)"
 msgstr ""
 
 #: ../../src/Pinball.cpp:673
-msgid "fire effect:       no"
+msgid "ratio:      1.3 (4/3)"
 msgstr ""
 
 #: ../../src/Pinball.cpp:674
-msgid "fire effect:      yes"
+msgid "ratio:      1.5 (3/2)"
+msgstr ""
+
+#: ../../src/Pinball.cpp:675
+msgid "ratio:    1.6 (16/10)"
+msgstr ""
+
+#: ../../src/Pinball.cpp:676
+msgid "ratio:     1.7 (16/9)"
+msgstr ""
+
+#: ../../src/Pinball.cpp:677
+msgid "ratio:      1.8 (9/5)"
 msgstr ""
 
 #: ../../src/Pinball.cpp:678
-msgid "dynamic lights:   yes"
+msgid "ratio:        2 (2/1)"
 msgstr ""
 
-#: ../../src/Pinball.cpp:679
-msgid "dynamic lights:    no"
+#: ../../src/Pinball.cpp:683
+msgid "texture:       nicest"
 msgstr ""
 
-#: ../../src/Pinball.cpp:688
-msgid "sound:            off"
+#: ../../src/Pinball.cpp:684
+msgid "texture:      fastest"
+msgstr ""
+
+#: ../../src/Pinball.cpp:685
+msgid "texture:         none"
 msgstr ""
 
 #: ../../src/Pinball.cpp:689
-msgid "sound:       =......."
+msgid "show fps:          no"
 msgstr ""
 
 #: ../../src/Pinball.cpp:690
-msgid "sound:       ==......"
-msgstr ""
-
-#: ../../src/Pinball.cpp:691
-msgid "sound:       ===....."
-msgstr ""
-
-#: ../../src/Pinball.cpp:692
-msgid "sound:       ====...."
-msgstr ""
-
-#: ../../src/Pinball.cpp:693
-msgid "sound:       =====..."
+msgid "show fps:         yes"
 msgstr ""
 
 #: ../../src/Pinball.cpp:694
-msgid "sound:       ======.."
+msgid "fire effect:       no"
 msgstr ""
 
 #: ../../src/Pinball.cpp:695
-msgid "sound:       =======."
+msgid "fire effect:      yes"
 msgstr ""
 
-#: ../../src/Pinball.cpp:696
-msgid "sound:       ========"
+#: ../../src/Pinball.cpp:699
+msgid "dynamic lights:   yes"
 msgstr ""
 
 #: ../../src/Pinball.cpp:700
-msgid "music:            off"
+msgid "dynamic lights:    no"
 msgstr ""
 
-#: ../../src/Pinball.cpp:701
-msgid "music:       =......."
+#: ../../src/Pinball.cpp:709
+msgid "sound:            off"
 msgstr ""
 
-#: ../../src/Pinball.cpp:702
-msgid "music:       ==......"
-msgstr ""
-
-#: ../../src/Pinball.cpp:703
-msgid "music:       ===....."
-msgstr ""
-
-#: ../../src/Pinball.cpp:704
-msgid "music:       ====...."
-msgstr ""
-
-#: ../../src/Pinball.cpp:705
-msgid "music:       =====..."
-msgstr ""
-
-#: ../../src/Pinball.cpp:706
-msgid "music:       ======.."
-msgstr ""
-
-#: ../../src/Pinball.cpp:707
-msgid "music:       =======."
-msgstr ""
-
-#: ../../src/Pinball.cpp:708
-msgid "music:       ========"
+#: ../../src/Pinball.cpp:710
+msgid "sound:       =......."
 msgstr ""
 
 #: ../../src/Pinball.cpp:711
-msgid "leftflip"
+msgid "sound:       ==......"
+msgstr ""
+
+#: ../../src/Pinball.cpp:712
+msgid "sound:       ===....."
 msgstr ""
 
 #: ../../src/Pinball.cpp:713
-msgid "rightflip"
+msgid "sound:       ====...."
+msgstr ""
+
+#: ../../src/Pinball.cpp:714
+msgid "sound:       =====..."
 msgstr ""
 
 #: ../../src/Pinball.cpp:715
-msgid "leftnudge"
+msgid "sound:       ======.."
+msgstr ""
+
+#: ../../src/Pinball.cpp:716
+msgid "sound:       =======."
 msgstr ""
 
 #: ../../src/Pinball.cpp:717
-msgid "rightnudge"
-msgstr ""
-
-#: ../../src/Pinball.cpp:719
-msgid "bottomnudge"
+msgid "sound:       ========"
 msgstr ""
 
 #: ../../src/Pinball.cpp:721
-msgid "launch"
+msgid "music:            off"
+msgstr ""
+
+#: ../../src/Pinball.cpp:722
+msgid "music:       =......."
 msgstr ""
 
 #: ../../src/Pinball.cpp:723
-msgid "reset"
+msgid "music:       ==......"
+msgstr ""
+
+#: ../../src/Pinball.cpp:724
+msgid "music:       ===....."
+msgstr ""
+
+#: ../../src/Pinball.cpp:725
+msgid "music:       ====...."
 msgstr ""
 
 #: ../../src/Pinball.cpp:726
-msgid "apply"
+msgid "music:       =====..."
+msgstr ""
+
+#: ../../src/Pinball.cpp:727
+msgid "music:       ======.."
+msgstr ""
+
+#: ../../src/Pinball.cpp:728
+msgid "music:       =======."
+msgstr ""
+
+#: ../../src/Pinball.cpp:729
+msgid "music:       ========"
 msgstr ""
 
 #: ../../src/Pinball.cpp:732
+msgid "leftflip"
+msgstr ""
+
+#: ../../src/Pinball.cpp:734
+msgid "rightflip"
+msgstr ""
+
+#: ../../src/Pinball.cpp:736
+msgid "leftnudge"
+msgstr ""
+
+#: ../../src/Pinball.cpp:738
+msgid "rightnudge"
+msgstr ""
+
+#: ../../src/Pinball.cpp:740
+msgid "bottomnudge"
+msgstr ""
+
+#: ../../src/Pinball.cpp:742
+msgid "launch"
+msgstr ""
+
+#: ../../src/Pinball.cpp:744
+msgid "reset"
+msgstr ""
+
+#: ../../src/Pinball.cpp:747
+msgid "apply"
+msgstr ""
+
+#: ../../src/Pinball.cpp:753
 msgid "back"
 msgstr ""
 
-#: ../../src/Pinball.cpp:824
+#: ../../src/Pinball.cpp:845
 msgid "no table loaded"
 msgstr ""
 
-#: ../../src/Pinball.cpp:825
+#: ../../src/Pinball.cpp:846
 msgid "press esc"
 msgstr ""
 
-#: ../../src/Score.cpp:88
-msgid "press enter to launch ball"
+#: ../../src/Score.cpp:91
+#, c-format
+msgid "press %s to launch ball"
 msgstr ""
 
-#: ../../src/Score.cpp:93
+#: ../../src/Score.cpp:97
 msgid "tilt"
 msgstr ""
 
-#: ../../src/Score.cpp:98
+#: ../../src/Score.cpp:102
 msgid "warning"
 msgstr ""
 
 #: ../../src/Score.cpp:119
+#, c-format
+msgid "press %s to start new game"
+msgstr ""
+
+#: ../../src/Score.cpp:124
 msgid "Last score was a High Score!"
 msgstr ""
 
-#: ../../src/Score.cpp:125
+#: ../../src/Score.cpp:130
 msgid "game over"
-msgstr ""
-
-#: ../../src/Score.cpp:126
-msgid "press r to start new game"
-msgstr ""
-
-#: ../../src/Score.cpp:136
-#, c-format
-msgid "SCORE %d BALL %d ExtraBall"
-msgstr ""
-
-#: ../../src/Score.cpp:138
-#, c-format
-msgid "SCORE %d BALL %d"
 msgstr ""
 
 #: ../../src/Score.cpp:141
 #, c-format
+msgid "SCORE %d BALL %d ExtraBall"
+msgstr ""
+
+#: ../../src/Score.cpp:143
+#, c-format
+msgid "SCORE %d BALL %d"
+msgstr ""
+
+#: ../../src/Score.cpp:146
+#, c-format
 msgid "SCORE %d"
 msgstr ""
 
-#: ../../src/Score.cpp:181
+#: ../../src/Score.cpp:186
 msgid "new highscore! enter name:"
 msgstr ""
 

--- a/data/locale/pinball_de_DE.po
+++ b/data/locale/pinball_de_DE.po
@@ -14,11 +14,20 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+#
+#
+#
+# Changed on Dec. 13, 2017 by c30zD
+#
+#   Some strings were removed by the tools when automatically updating this
+#   file, so they were manually fixed.
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: pinball 0.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-31 23:39+0200\n"
+"POT-Creation-Date: 2017-12-13 19:33+0100\n"
 "PO-Revision-Date: 2016-07-25 00:51+0200\n"
 "Last-Translator: Stephan Kreutzer <skreutzer@fsfe.org>\n"
 "Language-Team: German\n"
@@ -28,394 +37,408 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../../src/Pinball.cpp:107 ../../src/Pinball.cpp:515
+#: ../../src/Pinball.cpp:114 ../../src/Pinball.cpp:525
 msgid "High Scores"
 msgstr "Highscores"
 
-#: ../../src/Pinball.cpp:108
+#: ../../src/Pinball.cpp:115
 msgid "table: "
 msgstr "Tisch: "
 
-#: ../../src/Pinball.cpp:126
+#: ../../src/Pinball.cpp:133
 msgid "No Table Loaded!"
 msgstr "Kein Tisch geladen!"
 
-#: ../../src/Pinball.cpp:129
+#: ../../src/Pinball.cpp:136
 msgid "Hit any key for main menu..."
 msgstr "Taste druecken fuer Hauptmenue..."
 
-#: ../../src/Pinball.cpp:146
+#: ../../src/Pinball.cpp:153
 msgid "press a key"
 msgstr "Taste druecken"
 
-#: ../../src/Pinball.cpp:162 ../../base/Config.cpp:169
+#: ../../src/Pinball.cpp:169 ../../base/Config.cpp:169
 msgid "unknown"
 msgstr "unbekannt"
 
-#: ../../src/Pinball.cpp:374
+#: ../../src/Pinball.cpp:383
 msgid "LOADING"
 msgstr "LADE"
 
-#: ../../src/Pinball.cpp:386
+#: ../../src/Pinball.cpp:395
 msgid "OK"
 msgstr "OK"
 
-#: ../../src/Pinball.cpp:392
+#: ../../src/Pinball.cpp:401
 msgid "ERROR"
 msgstr "FEHLER"
 
-#: ../../src/Pinball.cpp:504
+#: ../../src/Pinball.cpp:515
 msgid "main menu"
 msgstr "Hauptmenue"
 
-#: ../../src/Pinball.cpp:507
+#: ../../src/Pinball.cpp:517
 msgid "play"
 msgstr "Spielen"
 
-#: ../../src/Pinball.cpp:511
+#: ../../src/Pinball.cpp:521
 msgid "load table"
 msgstr "Tisch laden"
 
-#: ../../src/Pinball.cpp:519
+#: ../../src/Pinball.cpp:529
 msgid "config"
 msgstr "Konfiguration"
 
-#: ../../src/Pinball.cpp:522
+#: ../../src/Pinball.cpp:532
 msgid "exit"
 msgstr "Beenden"
 
-#: ../../src/Pinball.cpp:526
+#: ../../src/Pinball.cpp:536
 msgid "graphics"
 msgstr "Grafik"
 
-#: ../../src/Pinball.cpp:529
+#: ../../src/Pinball.cpp:539
 msgid "audio"
 msgstr "Audio"
 
-#: ../../src/Pinball.cpp:532
+#: ../../src/Pinball.cpp:542
 msgid "keyboard"
 msgstr "Tastatur"
 
-#: ../../src/Pinball.cpp:533
+#: ../../src/Pinball.cpp:543
 msgid "shortcuts for view change F5-F8"
 msgstr "Shortcuts Aendern Ansicht F5-F8"
 
-#: ../../src/Pinball.cpp:613
+#: ../../src/Pinball.cpp:623
 msgid "view:         classic"
 msgstr "Ansicht:       klassisch"
 
-#: ../../src/Pinball.cpp:614
+#: ../../src/Pinball.cpp:624
 msgid "view:   softly moving"
 msgstr "Ansicht: langsam bewegen"
 
-#: ../../src/Pinball.cpp:615
+#: ../../src/Pinball.cpp:625
 msgid "view:          moving"
 msgstr "Ansicht:         bewegen"
 
-#: ../../src/Pinball.cpp:616
+#: ../../src/Pinball.cpp:626
 msgid "view:             top"
 msgstr "Ansicht:        von oben"
 
-#: ../../src/Pinball.cpp:620
+#: ../../src/Pinball.cpp:632
 msgid "screen:    fullscreen"
 msgstr "Modus:          Vollbild"
 
-#: ../../src/Pinball.cpp:621
+#: ../../src/Pinball.cpp:633
 msgid "screen:      windowed"
 msgstr "Modus:        im Fenster"
 
-#: ../../src/Pinball.cpp:625
+#: ../../src/Pinball.cpp:637
 msgid "brightness:    =....."
 msgstr "Helligkeit:       =....."
 
-#: ../../src/Pinball.cpp:626
+#: ../../src/Pinball.cpp:638
 msgid "brightness:    ==...."
 msgstr "Helligkeit:       ==...."
 
-#: ../../src/Pinball.cpp:627
+#: ../../src/Pinball.cpp:639
 msgid "brightness:    ===..."
 msgstr "Helligkeit:       ===..."
 
-#: ../../src/Pinball.cpp:628
+#: ../../src/Pinball.cpp:640
 msgid "brightness:    ====.."
 msgstr "Helligkeit:       ====.."
 
-#: ../../src/Pinball.cpp:629
+#: ../../src/Pinball.cpp:641
 msgid "brightness:    =====."
 msgstr "Helligkeit:       =====."
 
-#: ../../src/Pinball.cpp:630
+#: ../../src/Pinball.cpp:642
 msgid "brightness:    ======"
 msgstr "Helligkeit:       ======"
 
-#: ../../src/Pinball.cpp:635
-msgid "screen width:     340"
-msgstr "Bildschirmbreite:    340"
+#: ../../src/Pinball.cpp:647
+msgid "screen width:     320"
+msgstr "Bildschirmbreite:    320"
 
-#: ../../src/Pinball.cpp:636
+#: ../../src/Pinball.cpp:648
 msgid "screen width:     400"
 msgstr "Bildschirmbreite:    400"
 
-#: ../../src/Pinball.cpp:637
+#: ../../src/Pinball.cpp:649
 msgid "screen width:     512"
 msgstr "Bildschirmbreite:    512"
 
-#: ../../src/Pinball.cpp:638
+#: ../../src/Pinball.cpp:650
 msgid "screen width:     640"
 msgstr "Bildschirmbreite:    640"
 
-#: ../../src/Pinball.cpp:639
+#: ../../src/Pinball.cpp:651
+msgid "screen width:     720"
+msgstr "Bildschirmbreite:    720"
+
+#: ../../src/Pinball.cpp:652
 msgid "screen width:     800"
 msgstr "Bildschirmbreite:    800"
 
-#: ../../src/Pinball.cpp:640
+#: ../../src/Pinball.cpp:653
 msgid "screen width:     864"
 msgstr "Bildschirmbreite:    864"
 
-#: ../../src/Pinball.cpp:641
-msgid "screen width:    1024"
-msgstr "Bildschirmbreite:   1014"
+#: ../../src/Pinball.cpp:654
+msgid "screen width:     900"
+msgstr "Bildschirmbreite:    900"
 
-#: ../../src/Pinball.cpp:642
+#: ../../src/Pinball.cpp:655
+msgid "screen width:    1024"
+msgstr "Bildschirmbreite:   1024"
+
+#: ../../src/Pinball.cpp:656
+msgid "screen width:    1080"
+msgstr "Bildschirmbreite:   1080"
+
+#: ../../src/Pinball.cpp:657
 msgid "screen width:    1280"
 msgstr "Bildschirmbreite:   1280"
 
-#: ../../src/Pinball.cpp:643
+#: ../../src/Pinball.cpp:658
 msgid "screen width:    1680"
 msgstr "Bildschirmbreite:   1680"
 
-#: ../../src/Pinball.cpp:644
+#: ../../src/Pinball.cpp:659
 msgid "screen width:    1920"
 msgstr "Bildschirmbreite:   1920"
 
-#: ../../src/Pinball.cpp:649
+#: ../../src/Pinball.cpp:664
 msgid "ratio:      0.5 (1/2)"
 msgstr "Verhaeltnis:   0,5 (1/2)"
 
-#: ../../src/Pinball.cpp:650
+#: ../../src/Pinball.cpp:671
 msgid "ratio:        1 (1/1)"
 msgstr "Verhaeltnis:     1 (1/1)"
 
-#: ../../src/Pinball.cpp:651
+#: ../../src/Pinball.cpp:672
 msgid "ratio:      1.2 (5/4)"
 msgstr "Verhaeltnis:   1,2 (5/4)"
 
-#: ../../src/Pinball.cpp:652
+#: ../../src/Pinball.cpp:673
 msgid "ratio:      1.3 (4/3)"
 msgstr "Verhaeltnis:   1,3 (4/3)"
 
-#: ../../src/Pinball.cpp:653
+#: ../../src/Pinball.cpp:674
 msgid "ratio:      1.5 (3/2)"
 msgstr "Verhaeltnis:   1,5 (3/2)"
 
-#: ../../src/Pinball.cpp:654
+#: ../../src/Pinball.cpp:675
 msgid "ratio:    1.6 (16/10)"
 msgstr "Verhaeltnis: 1,6 (16/10)"
 
-#: ../../src/Pinball.cpp:655
+#: ../../src/Pinball.cpp:676
 msgid "ratio:     1.7 (16/9)"
 msgstr "Verhaeltnis:  1,7 (16/9)"
 
-#: ../../src/Pinball.cpp:656
+#: ../../src/Pinball.cpp:677
 msgid "ratio:      1.8 (9/5)"
 msgstr "Verhaeltnis:   1,8 (9/5)"
 
-#: ../../src/Pinball.cpp:657
+#: ../../src/Pinball.cpp:678
 msgid "ratio:        2 (2/1)"
 msgstr "Verhaeltnis:     2 (2/1)"
 
-#: ../../src/Pinball.cpp:662
+#: ../../src/Pinball.cpp:683
 msgid "texture:       nicest"
 msgstr "Texturen:         schoen"
 
-#: ../../src/Pinball.cpp:663
+#: ../../src/Pinball.cpp:684
 msgid "texture:      fastest"
 msgstr "Texturen:        schnell"
 
-#: ../../src/Pinball.cpp:664
+#: ../../src/Pinball.cpp:685
 msgid "texture:         none"
 msgstr "Texturen:          keine"
 
-#: ../../src/Pinball.cpp:668
+#: ../../src/Pinball.cpp:689
 msgid "show fps:          no"
 msgstr "Zeige FPS:          nein"
 
-#: ../../src/Pinball.cpp:669
+#: ../../src/Pinball.cpp:690
 msgid "show fps:         yes"
 msgstr "Zeige FPS:            ja"
 
-#: ../../src/Pinball.cpp:673
+#: ../../src/Pinball.cpp:694
 msgid "fire effect:       no"
 msgstr "Schusseffekt:       nein"
 
-#: ../../src/Pinball.cpp:674
+#: ../../src/Pinball.cpp:695
 msgid "fire effect:      yes"
 msgstr "Schusseffekt:         ja"
 
-#: ../../src/Pinball.cpp:678
+#: ../../src/Pinball.cpp:699
 msgid "dynamic lights:   yes"
 msgstr "Dynamische Lichter:   ja"
 
-#: ../../src/Pinball.cpp:679
+#: ../../src/Pinball.cpp:700
 msgid "dynamic lights:    no"
 msgstr "Dynamische Lichter: nein"
 
-#: ../../src/Pinball.cpp:688
+#: ../../src/Pinball.cpp:709
 msgid "sound:            off"
 msgstr "Ton:              aus"
 
-#: ../../src/Pinball.cpp:689
+#: ../../src/Pinball.cpp:710
 msgid "sound:       =......."
 msgstr "Ton:         =......."
 
-#: ../../src/Pinball.cpp:690
+#: ../../src/Pinball.cpp:711
 msgid "sound:       ==......"
 msgstr "Ton:         ==......"
 
-#: ../../src/Pinball.cpp:691
+#: ../../src/Pinball.cpp:712
 msgid "sound:       ===....."
 msgstr "Ton:         ===....."
 
-#: ../../src/Pinball.cpp:692
+#: ../../src/Pinball.cpp:713
 msgid "sound:       ====...."
 msgstr "Ton:         ====...."
 
-#: ../../src/Pinball.cpp:693
+#: ../../src/Pinball.cpp:714
 msgid "sound:       =====..."
 msgstr "Ton:         =====..."
 
-#: ../../src/Pinball.cpp:694
+#: ../../src/Pinball.cpp:715
 msgid "sound:       ======.."
 msgstr "Ton:         ======.."
 
-#: ../../src/Pinball.cpp:695
+#: ../../src/Pinball.cpp:716
 msgid "sound:       =======."
 msgstr "Ton:         =======."
 
-#: ../../src/Pinball.cpp:696
+#: ../../src/Pinball.cpp:717
 msgid "sound:       ========"
 msgstr "Ton:         ========"
 
-#: ../../src/Pinball.cpp:700
+#: ../../src/Pinball.cpp:721
 msgid "music:            off"
 msgstr "Musik:            aus"
 
-#: ../../src/Pinball.cpp:701
+#: ../../src/Pinball.cpp:722
 msgid "music:       =......."
 msgstr "Musik:       =......."
 
-#: ../../src/Pinball.cpp:702
+#: ../../src/Pinball.cpp:723
 msgid "music:       ==......"
 msgstr "Musik:       ==......"
 
-#: ../../src/Pinball.cpp:703
+#: ../../src/Pinball.cpp:724
 msgid "music:       ===....."
 msgstr "Musik:       ===....."
 
-#: ../../src/Pinball.cpp:704
+#: ../../src/Pinball.cpp:725
 msgid "music:       ====...."
 msgstr "Musik:       ====...."
 
-#: ../../src/Pinball.cpp:705
+#: ../../src/Pinball.cpp:726
 msgid "music:       =====..."
 msgstr "Musik:       =====..."
 
-#: ../../src/Pinball.cpp:706
+#: ../../src/Pinball.cpp:727
 msgid "music:       ======.."
 msgstr "Musik:       ======.."
 
-#: ../../src/Pinball.cpp:707
+#: ../../src/Pinball.cpp:728
 msgid "music:       =======."
 msgstr "Musik:       =======."
 
-#: ../../src/Pinball.cpp:708
+#: ../../src/Pinball.cpp:729
 msgid "music:       ========"
 msgstr "Musik:       ========"
 
-#: ../../src/Pinball.cpp:711
+#: ../../src/Pinball.cpp:732
 msgid "leftflip"
 msgstr "Linker Flipper"
 
-#: ../../src/Pinball.cpp:713
+#: ../../src/Pinball.cpp:734
 msgid "rightflip"
 msgstr "Rechter Flipper"
 
-#: ../../src/Pinball.cpp:715
+#: ../../src/Pinball.cpp:736
 msgid "leftnudge"
 msgstr "Stoss links"
 
-#: ../../src/Pinball.cpp:717
+#: ../../src/Pinball.cpp:738
 msgid "rightnudge"
 msgstr "Stoss rechts"
 
-#: ../../src/Pinball.cpp:719
+#: ../../src/Pinball.cpp:740
 msgid "bottomnudge"
 msgstr "Stoss unten"
 
-#: ../../src/Pinball.cpp:721
+#: ../../src/Pinball.cpp:742
 msgid "launch"
 msgstr "Abschuss"
 
-#: ../../src/Pinball.cpp:723
+#: ../../src/Pinball.cpp:744
 msgid "reset"
 msgstr "Zuruecksetzen"
 
-#: ../../src/Pinball.cpp:726
+#: ../../src/Pinball.cpp:747
 msgid "apply"
 msgstr "Anwenden"
 
-#: ../../src/Pinball.cpp:732
+#: ../../src/Pinball.cpp:753
 msgid "back"
 msgstr "Zurueck"
 
-#: ../../src/Pinball.cpp:824
+#: ../../src/Pinball.cpp:845
 msgid "no table loaded"
 msgstr "Kein Tisch geladen"
 
-#: ../../src/Pinball.cpp:825
+#: ../../src/Pinball.cpp:846
 msgid "press esc"
 msgstr "ESC druecken"
 
-#: ../../src/Score.cpp:88
-msgid "press enter to launch ball"
-msgstr "Druecke Enter, um Ball abzufeuern"
+#: ../../src/Score.cpp:91
+#, c-format
+msgid "press %s to launch ball"
+msgstr "Druecke %s, um Ball abzufeuern"
 
-#: ../../src/Score.cpp:93
+#: ../../src/Score.cpp:97
 msgid "tilt"
 msgstr "Tilt-Strafe"
 
-#: ../../src/Score.cpp:98
+#: ../../src/Score.cpp:102
 msgid "warning"
 msgstr "Warnung"
 
 #: ../../src/Score.cpp:119
+#, c-format
+msgid "press %s to start new game"
+msgstr "Druecke %s fuer neues Spiel"
+
+#: ../../src/Score.cpp:124
 msgid "Last score was a High Score!"
 msgstr "Punktestand war Highscore!"
 
-#: ../../src/Score.cpp:125
+#: ../../src/Score.cpp:130
 msgid "game over"
 msgstr "Spiel vorbei"
 
-#: ../../src/Score.cpp:126
-msgid "press r to start new game"
-msgstr "Druecke r fuer neues Spiel"
-
-#: ../../src/Score.cpp:136
+#: ../../src/Score.cpp:141
 #, c-format
 msgid "SCORE %d BALL %d ExtraBall"
 msgstr "PUNKTE %d BALL %d Extra-Ball"
 
-#: ../../src/Score.cpp:138
+#: ../../src/Score.cpp:143
 #, c-format
 msgid "SCORE %d BALL %d"
 msgstr "PUNKTE %d BALL %d"
 
-#: ../../src/Score.cpp:141
+#: ../../src/Score.cpp:146
 #, c-format
 msgid "SCORE %d"
 msgstr "PUNKTE %d"
 
-#: ../../src/Score.cpp:181
+#: ../../src/Score.cpp:186
 msgid "new highscore! enter name:"
 msgstr "Neuer Highscore! Name eingeben:"
 
@@ -554,3 +577,6 @@ msgstr "Vierte Hurd-Entwicklung"
 #: ../hurd/ModuleHurd.cpp:432
 msgid "hurd is stable"
 msgstr "Hurd ist stabil"
+
+#~ msgid "screen width:     340"
+#~ msgstr "Bildschirmbreite:    340"

--- a/src/ArmBehavior.cpp
+++ b/src/ArmBehavior.cpp
@@ -4,6 +4,15 @@
     begin                : Wed Jan 26 2000
     copyright            : (C) 2000 by Henrik Enqvist
     email                : henqvist@excite.com
+
+
+    ========================= Modifications =========================
+
+        Apr. 6, 2017:
+            - Replace name of "m_bOn" with "m_bActive". (c30zD)
+            - Add events for game over and game start signals. (c30zD)
+            - Modify function doArm to also use m_bActive. (c30zD)
+
  ***************************************************************************/
 
 #include "Private.h"

--- a/src/ArmBehavior.h
+++ b/src/ArmBehavior.h
@@ -4,6 +4,13 @@
     begin                : Wed Jan 26 2000
     copyright            : (C) 2000 by 
     email                : 
+
+
+    ========================= Modifications =========================
+
+        Apr. 6, 2017:
+            Replace name of "m_bOn" with "m_bActive". (c30zD)
+
  ***************************************************************************/
 
 #ifndef ARMBEHAVIOR_H

--- a/src/Pinball.cpp
+++ b/src/Pinball.cpp
@@ -823,7 +823,7 @@ int main(int argc, char *argv[]) {
         SoundUtil::getInstance()->resumeMusic();
       }
 
-      if (Keyboard::isKeyDown(SDLK_r)) {
+      if (Keyboard::isKeyDown(Config::getInstance()->getKey("reset"))) {
         SendSignal(PBL_SIG_RESET_ALL, 0, engine, NULL);
       }
 

--- a/src/Score.cpp
+++ b/src/Score.cpp
@@ -82,10 +82,14 @@ void Score::onTick() {
 
 void Score::StdOnSignal() {
   EM_COUT((int)em_signal, 1);
+  Config *cfg = Config::getInstance();
 
   OnSignal( PBL_SIG_RESET_ALL ) {
     this->clear();
-    this->setText1(gettext("press enter to launch ball"));
+    std::string txt = "press ";
+    txt += string(cfg->getKeyCommonName(cfg->getKey("launch")));
+    txt += string(" to launch ball");
+    this->setText1(gettext(txt.c_str()));
     SendSignal( PBL_SIG_CLEAR_TEXT, 400, this->getParent(), NULL );
   } 
   ElseOnSignal( PBL_SIG_TILT ) {
@@ -112,6 +116,9 @@ void Score::StdOnSignal() {
   }
   ElseOnSignal( PBL_SIG_GAME_OVER ) {
     this->clearText();
+    std::string txt = "press ";
+    txt += string(cfg->getKeyCommonName(cfg->getKey("reset")));
+    txt += string(" to start new game");
 
     //cout<<" TODO:give (only) one extra ball if high score"<<endl; //!rzr
 
@@ -123,7 +130,7 @@ void Score::StdOnSignal() {
 
     this->setText2("");
     this->setText3(gettext("game over"));
-    this->setText4(gettext("press r to start new game"));
+    this->setText4(gettext(txt.c_str()));
   }
 }
 

--- a/src/Score.cpp
+++ b/src/Score.cpp
@@ -10,6 +10,7 @@
     20030510  pnf        : Display message ExtraBall when flag activated
                             for current ball.
     20171209  c30zD      : Correctly display the "reset" and "launch" keys.
+    20171213  c30zD      : Fix previous strings for gettext usage.
 
 ***************************************************************************/
 
@@ -84,13 +85,12 @@ void Score::onTick() {
 void Score::StdOnSignal() {
   EM_COUT((int)em_signal, 1);
   Config *cfg = Config::getInstance();
+  char pStrMsg[35];
 
   OnSignal( PBL_SIG_RESET_ALL ) {
     this->clear();
-    std::string txt = "press ";
-    txt += string(cfg->getKeyCommonName(cfg->getKey("launch")));
-    txt += string(" to launch ball");
-    this->setText1(gettext(txt.c_str()));
+    sprintf(pStrMsg, gettext("press %s to launch ball"), cfg->getKeyCommonName(cfg->getKey("launch")));
+    this->setText1(pStrMsg);
     SendSignal( PBL_SIG_CLEAR_TEXT, 400, this->getParent(), NULL );
   } 
   ElseOnSignal( PBL_SIG_TILT ) {
@@ -117,9 +117,7 @@ void Score::StdOnSignal() {
   }
   ElseOnSignal( PBL_SIG_GAME_OVER ) {
     this->clearText();
-    std::string txt = "press ";
-    txt += string(cfg->getKeyCommonName(cfg->getKey("reset")));
-    txt += string(" to start new game");
+    sprintf(pStrMsg, gettext("press %s to start new game"), cfg->getKeyCommonName(cfg->getKey("reset")));
 
     //cout<<" TODO:give (only) one extra ball if high score"<<endl; //!rzr
 
@@ -131,7 +129,7 @@ void Score::StdOnSignal() {
 
     this->setText2("");
     this->setText3(gettext("game over"));
-    this->setText4(gettext(txt.c_str()));
+    this->setText4(pStrMsg);
   }
 }
 

--- a/src/StateBehavior.cpp
+++ b/src/StateBehavior.cpp
@@ -4,6 +4,13 @@
     begin                : Thu Jan 25 2001
     copyright            : (C) 2001 by Henrik Enqvist
     email                : henqvist@excite.com
+
+
+    ========================= Modifications =========================
+
+        Apr. 4, 2017:
+            Clear the keyboard on game reset. (c30zD)
+
 ***************************************************************************/
 
 #include "Private.h"


### PR DESCRIPTION
This fixes an issue with the on-screen messages for reset and ball launch, which weren't updated even though the settings for them were modified. There is also a fix for the reset functionality, which was hard-coded to letter "R", instead of using the user's settings.

The German localization files have been updated, but I haven't tested them. I did modify one of the files manually because some strings were missing after the automatic update.

There is an issue that, even though it's unlikely to be seen, it's still there: for example, the message that says something like "press return to launch ball", once rendered, if the user wishes to change its value and then returns to the game, then the message will still be the same until it is rendered again (i.e. after a reset). This also happens with the reset message. I don't think it's necessary to change this, because most people would not stop the game to change the settings to launch the ball or reset the game just after they see them, but it's worth noting that the issue is there and it would be a good idea to fix it in the future. However, I'm not planning to work on it any time soon.