### PR TITLE
Use a sys version of ltdl

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 AUTOMAKE_OPTIONS = gnu
 
-SUBDIRS = libltdl addon base data src test
+SUBDIRS = addon base data src test
 
 EXTRA_DIST = bootstrap pinball.spec clean pinball.desktop
 
@@ -10,4 +10,4 @@ pininclude_HEADERS = pinconfig.h
 
 bin_SCRIPTS = pinball-config
 
-ACLOCAL_AMFLAGS = -I libltdl/m4
+ACLOCAL_AMFLAGS =

--- a/configure.ac
+++ b/configure.ac
@@ -4,10 +4,6 @@ dnl init autoconf and automake
 AC_INIT(pinball, 0.3.4.1)
 
 AC_CONFIG_HEADERS(pinconfig.h)
-LT_CONFIG_LTDL_DIR([libltdl])
-AC_CONFIG_AUX_DIR([libltdl/config])
-AC_CONFIG_MACRO_DIR([libltdl/m4])
-
 AC_CANONICAL_HOST
 AC_CANONICAL_TARGET
 
@@ -37,7 +33,6 @@ AC_ARG_WITH(cxxflags,
     [CXXFLAGS=$with_cxxflags; export CXXFLAGS])
 
 AC_LIBTOOL_DLOPEN
-LTDL_INIT
 
 dnl *******************************************
 dnl PATHS AND DIRS ****************************

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,10 +7,10 @@ pinlib_LIBRARIES = libemilia_pin.a
 
 bin_PROGRAMS = pinball
 
-AM_CPPFLAGS = -I../base -I../addon @INCLTDL@
+AM_CPPFLAGS = -I../base -I../addon
 
 pinball_LDADD = \
- libemilia_pin.a ../addon/libemilia_addon.a ../base/libemilia_base.a @LIBLTDL@
+ libemilia_pin.a ../addon/libemilia_addon.a ../base/libemilia_base.a -lltdl
 
 pinball_LDFLAGS = -export-dynamic
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -5,8 +5,8 @@ testdatadir = $(pkgdatadir)
 
 noinst_PROGRAMS = scale simple light texture load explode collision signal billboard font thread menu joy sound trans math misc varray unittest
 
-AM_CPPFLAGS = -I../base -I../addon -I../src @INCLTDL@
-LDADD = ../src/libemilia_pin.a ../addon/libemilia_addon.a ../base/libemilia_base.a @LIBLTDL@
+AM_CPPFLAGS = -I../base -I../addon -I../src
+LDADD = ../src/libemilia_pin.a ../addon/libemilia_addon.a ../base/libemilia_base.a -lltdl
 
 testlib_LTLIBRARIES = libModuleTest.la
 


### PR DESCRIPTION
This is adapted from an old patch against pinball 0.3.1. It avoids issues when trying to build with the included version of ltdl as tested on Slackware64-current. It also makes configure much faster.

I'm not sure I did this entirely right so please review, it does work here at least.
```
$ make
make  all-recursive
make[1]: Entering directory '/media/gittings/forks/pinball'
Making all in libltdl
make[2]: Entering directory '/media/gittings/forks/pinball/libltdl'
CDPATH="${ZSH_VERSION+.}:" && cd . && /bin/sh /home/orbea/gittings/forks/pinball/libltdl/config/missing aclocal-1.15 -I m4
/home/orbea/gittings/forks/pinball/libltdl/config/missing: line 81: aclocal-1.15: command not found
WARNING: 'aclocal-1.15' is missing on your system.
         You should only need it if you modified 'acinclude.m4' or
         'configure.ac' or m4 files included by 'configure.ac'.
         The 'aclocal' program is part of the GNU Automake package:
         <https://www.gnu.org/software/automake>
         It also requires GNU Autoconf, GNU m4 and Perl in order to run:
         <https://www.gnu.org/software/autoconf>
         <https://www.gnu.org/software/m4/>
         <https://www.perl.org/>
make[2]: *** [Makefile:539: aclocal.m4] Error 127
make[2]: Leaving directory '/media/gittings/forks/pinball/libltdl'
make[1]: *** [Makefile:575: all-recursive] Error 1
make[1]: Leaving directory '/media/gittings/forks/pinball'
make: *** [Makefile:449: all] Error 2
```