### PR TITLE
Bugfix : config width can't be saved if it is bigger than 1600 pixels

### DIFF
--- a/base/Config.cpp
+++ b/base/Config.cpp
@@ -322,8 +322,8 @@ void Config::loadConfig() {
 
 void Config::setSize(int const w, int h) { 
   if ( h == 0 ) { h = w; }
-  m_iWidth = EM_MIN(1600, EM_MAX(100,w)); 
-  m_iHeight = EM_MIN(1200, EM_MAX(100,h)); 
+  m_iWidth = EM_MIN(8000, EM_MAX(100,w)); 
+  m_iHeight = EM_MIN(4000, EM_MAX(100,h)); 
   m_iWidthDiv2 = m_iWidth/2;
   m_iHeightDiv2 = m_iHeight/2;
 }


### PR DESCRIPTION
I had this bug in my system, hitting apply on 1680 width brings back 320 width.
I tested this silly fix, which expects biggest screens to be the 8K things.