### PR TITLE
Fix build issue with gettext-0.20.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,6 +19,7 @@ AM_GNU_GETTEXT([external])
 #For rhel6 but rhel6 doesn't have SDL2
 #AM_GNU_GETTEXT_VERSION(0.17)
 AM_GNU_GETTEXT_VERSION(0.19.8)
+AM_GNU_GETTEXT_REQUIRE_VERSION([0.19.8])
 
 dnl this is a c++ program
 dnl CFLAGS="-g -W -Wall -O2"


### PR DESCRIPTION
Fixes a build issue with `gettext-0.20`.
```
*** error: gettext infrastructure mismatch: using a Makefile.in.in from gettext version 0.19 but the autoconf macros are from gettext version 0.20
```

Reference:
https://gitlab.gnome.org/GNOME/gcr/merge_requests/17
https://gitlab.gnome.org/GNOME/gcr/commit/3c2d5803b1149a0d2ea1669fac8874f903e30c22